### PR TITLE
Release/v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,52 @@ print(process_data("21"))  # "Result: 42"
 print(process_data("abc"))  # "Result: 0"
 ```
 
+### run_catching_with Function
+
+The `run_catching_with` function executes a function with a receiver object as the first argument. This is similar to Kotlin's extension function version of runCatching.
+
+**Note**: In Kotlin, there are two versions of `runCatching`:
+1. Regular function: `runCatching { ... }`
+2. Extension function: `someObject.runCatching { ... }`
+
+Since Python doesn't have extension functions, we implement the extension function version as a separate function called `run_catching_with`, where the receiver object is explicitly passed as the first parameter.
+
+```python
+from kotresult import run_catching_with
+
+# Basic usage with string operations
+# Kotlin: "hello".runCatching { toUpperCase() }
+# Python equivalent:
+result = run_catching_with("hello", str.upper)
+print(result.get_or_null())  # "HELLO"
+
+# With a custom function
+def add_prefix(text, prefix):
+    return prefix + text
+
+result = run_catching_with("world", add_prefix, "Hello, ")
+print(result.get_or_null())  # "Hello, world"
+
+# With lambda functions
+result = run_catching_with(42, lambda x: x * 2)
+print(result.get_or_null())  # 84
+
+# Type conversion with error handling
+result = run_catching_with("123", int)
+print(result.get_or_null())  # 123
+
+result = run_catching_with("not a number", int)
+print(result.is_failure)  # True
+print(type(result.exception_or_null()))  # <class 'ValueError'>
+
+# Chaining operations with receiver
+def process_text(text):
+    return text.strip().lower().replace(" ", "_")
+
+result = run_catching_with("  Hello World  ", process_text)
+print(result.get_or_null())  # "hello_world"
+```
+
 ## API Reference
 
 ### Result Class
@@ -273,8 +319,10 @@ print(process_data("abc"))  # "Result: 0"
 
 #### Methods
 
-- `get_or_none()`: Returns the value if success, `None` if failure
-- `exception_or_none()`: Returns the exception if failure, `None` if success
+- `get_or_null()`: Returns the value if success, `None` if failure
+- `get_or_none()`: Alias for `get_or_null()` for Python naming convention
+- `exception_or_null()`: Returns the exception if failure, `None` if success
+- `exception_or_none()`: Alias for `exception_or_null()` for Python naming convention
 - `to_string()`: Returns a string representation of the result
 - `get_or_default(default_value)`: Returns the value if success, the default value if failure
 - `get_or_throw()`: Returns the value if success, throws the exception if failure
@@ -291,6 +339,10 @@ print(process_data("abc"))  # "Result: 0"
 ### run_catching Function
 
 - `run_catching(func, *args, **kwargs)`: Executes the function with the given arguments and returns a `Result` object
+
+### run_catching_with Function
+
+- `run_catching_with(receiver, func, *args, **kwargs)`: Executes the function with a receiver object as the first argument and returns a `Result` object
 
 ## License
 

--- a/kotresult/__init__.py
+++ b/kotresult/__init__.py
@@ -1,4 +1,4 @@
 from kotresult.result import Result
-from kotresult.run_catching import run_catching
+from kotresult.run_catching import run_catching, run_catching_with
 
 __version__ = '0.2.0'

--- a/kotresult/__init__.py
+++ b/kotresult/__init__.py
@@ -1,4 +1,4 @@
 from kotresult.result import Result
 from kotresult.run_catching import run_catching, run_catching_with
 
-__version__ = '0.2.0'
+__version__ = '1.0.0'

--- a/kotresult/run_catching.py
+++ b/kotresult/run_catching.py
@@ -3,10 +3,43 @@ from typing import Callable, TypeVar
 from kotresult.result import Result
 
 T = TypeVar('T')
+R = TypeVar('R')
 
 
 def run_catching(func: Callable[..., T], *args, **kwargs) -> Result[T]:
     try:
         return Result.success(func(*args, **kwargs))
+    except BaseException as e:
+        return Result.failure(e)
+
+
+def run_catching_with(receiver: T, func: Callable[..., R], *args, **kwargs) -> Result[R]:
+    """
+    Execute a function with a receiver object as the first argument.
+    This is similar to Kotlin's extension function version of runCatching.
+    
+    In Kotlin, there are two versions of runCatching:
+    1. Regular function: runCatching { ... }
+    2. Extension function: someObject.runCatching { ... }
+    
+    This function implements the equivalent of Kotlin's extension function version,
+    where the receiver object is passed as the first argument to the function.
+    Since Python doesn't have extension functions, we implement it as a separate function.
+    
+    Args:
+        receiver: The object to pass as the first argument to func
+        func: The function to execute with receiver as the first argument
+        *args: Additional positional arguments for func
+        **kwargs: Keyword arguments for func
+        
+    Returns:
+        Result containing either the function's return value or any raised exception
+    
+    Example:
+        # Kotlin: "hello".runCatching { this.toUpperCase() }
+        # Python: run_catching_with("hello", str.upper)
+    """
+    try:
+        return Result.success(func(receiver, *args, **kwargs))
     except BaseException as e:
         return Result.failure(e)

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -9,8 +9,8 @@ class TestResult(unittest.TestCase):
         result = Result.success("test value")
         self.assertTrue(result.is_success)
         self.assertFalse(result.is_failure)
-        self.assertEqual(result.get_or_none(), "test value")
-        self.assertIsNone(result.exception_or_none())
+        self.assertEqual(result.get_or_null(), "test value")
+        self.assertIsNone(result.exception_or_null())
 
     def test_failure_creation(self):
         """Test creating a failure Result"""
@@ -18,8 +18,8 @@ class TestResult(unittest.TestCase):
         result = Result.failure(exception)
         self.assertFalse(result.is_success)
         self.assertTrue(result.is_failure)
-        self.assertIsNone(result.get_or_none())
-        self.assertEqual(result.exception_or_none(), exception)
+        self.assertIsNone(result.get_or_null())
+        self.assertEqual(result.exception_or_null(), exception)
 
     def test_to_string(self):
         """Test the to_string method"""
@@ -81,6 +81,10 @@ class TestResult(unittest.TestCase):
         failure_result.on_success(success_callback)
         self.assertIsNone(success_value)
 
+        # on_success with exception in callback should throw
+        with self.assertRaises(RuntimeError):
+            success_result.on_success(lambda x: exec("raise RuntimeError('on_success error')"))
+
     def test_on_failure(self):
         """Test the on_failure method"""
         success_result = Result.success("test value")
@@ -102,6 +106,10 @@ class TestResult(unittest.TestCase):
         failure_exception = None
         success_result.on_failure(failure_callback)
         self.assertIsNone(failure_exception)
+
+        # on_failure with exception in callback should throw
+        with self.assertRaises(RuntimeError):
+            failure_result.on_failure(lambda e: exec("raise RuntimeError('on_failure error')"))
 
     def test_method_chaining(self):
         """Test method chaining with on_success and on_failure"""
@@ -132,3 +140,228 @@ class TestResult(unittest.TestCase):
         failure_result.on_success(success_callback).on_failure(failure_callback)
         self.assertIsNone(success_value)
         self.assertIsInstance(failure_exception, ValueError)
+
+    def test_map(self):
+        """Test the map method"""
+        success_result = Result.success(10)
+        failure_result = Result.failure(ValueError("test error"))
+
+        # Map on success should transform the value
+        mapped_success = success_result.map(lambda x: x * 2)
+        self.assertTrue(mapped_success.is_success)
+        self.assertEqual(mapped_success.get_or_null(), 20)
+
+        # Map on failure should return the same failure
+        mapped_failure = failure_result.map(lambda x: x * 2)
+        self.assertTrue(mapped_failure.is_failure)
+        self.assertIsInstance(mapped_failure.exception_or_null(), ValueError)
+
+        # Map with exception in lambda should throw
+        with self.assertRaises(ZeroDivisionError):
+            success_result.map(lambda x: 1 / 0)
+
+    def test_map_catching(self):
+        """Test the map_catching method"""
+        success_result = Result.success(10)
+        failure_result = Result.failure(ValueError("test error"))
+
+        # Map catching on success with valid transform
+        mapped_success = success_result.map_catching(lambda x: x * 2)
+        self.assertTrue(mapped_success.is_success)
+        self.assertEqual(mapped_success.get_or_null(), 20)
+
+        # Map catching on success with exception-throwing transform
+        mapped_exception = success_result.map_catching(lambda x: 1 / 0)
+        self.assertTrue(mapped_exception.is_failure)
+        self.assertIsInstance(mapped_exception.exception_or_null(), ZeroDivisionError)
+
+        # Map catching on failure should return the same failure
+        mapped_failure = failure_result.map_catching(lambda x: x * 2)
+        self.assertTrue(mapped_failure.is_failure)
+        self.assertIsInstance(mapped_failure.exception_or_null(), ValueError)
+
+    def test_recover(self):
+        """Test the recover method"""
+        success_result = Result.success(10)
+        failure_result = Result.failure(ValueError("test error"))
+
+        # Recover on success should return the same result
+        recovered_success = success_result.recover(lambda e: 42)
+        self.assertTrue(recovered_success.is_success)
+        self.assertEqual(recovered_success.get_or_null(), 10)
+
+        # Recover on failure should transform to success
+        recovered_failure = failure_result.recover(lambda e: 42)
+        self.assertTrue(recovered_failure.is_success)
+        self.assertEqual(recovered_failure.get_or_null(), 42)
+
+        # Recover with exception in lambda should throw
+        with self.assertRaises(ZeroDivisionError):
+            failure_result.recover(lambda e: 1 / 0)
+
+    def test_recover_catching(self):
+        """Test the recover_catching method"""
+        success_result = Result.success(10)
+        failure_result = Result.failure(ValueError("test error"))
+
+        # Recover catching on success should return the same result
+        recovered_success = success_result.recover_catching(lambda e: 42)
+        self.assertTrue(recovered_success.is_success)
+        self.assertEqual(recovered_success.get_or_null(), 10)
+
+        # Recover catching on failure with valid transform
+        recovered_failure = failure_result.recover_catching(lambda e: 42)
+        self.assertTrue(recovered_failure.is_success)
+        self.assertEqual(recovered_failure.get_or_null(), 42)
+
+        # Recover catching on failure with exception-throwing transform
+        recovered_exception = failure_result.recover_catching(lambda e: 1 / 0)
+        self.assertTrue(recovered_exception.is_failure)
+        self.assertIsInstance(recovered_exception.exception_or_null(), ZeroDivisionError)
+
+    def test_fold(self):
+        """Test the fold method"""
+        success_result = Result.success(10)
+        failure_result = Result.failure(ValueError("test error"))
+
+        # Fold on success should call onSuccess
+        success_value = success_result.fold(
+            on_success=lambda x: f"Success: {x}",
+            on_failure=lambda e: f"Failure: {e}"
+        )
+        self.assertEqual(success_value, "Success: 10")
+
+        # Fold on failure should call onFailure
+        failure_value = failure_result.fold(
+            on_success=lambda x: f"Success: {x}",
+            on_failure=lambda e: f"Failure: {e}"
+        )
+        self.assertEqual(failure_value, "Failure: test error")
+
+        # Fold with exception in onSuccess lambda should throw
+        with self.assertRaises(ZeroDivisionError):
+            success_result.fold(
+                on_success=lambda x: 1 / 0,
+                on_failure=lambda e: "error"
+            )
+
+        # Fold with exception in onFailure lambda should throw
+        with self.assertRaises(RuntimeError):
+            failure_result.fold(
+                on_success=lambda x: "success",
+                on_failure=lambda e: exec("raise RuntimeError('fold error')")
+            )
+
+    def test_get_or_else(self):
+        """Test the get_or_else method"""
+        success_result = Result.success(10)
+        failure_result = Result.failure(ValueError("test error"))
+
+        # get_or_else on success should return the value
+        success_value = success_result.get_or_else(lambda e: 42)
+        self.assertEqual(success_value, 10)
+
+        # get_or_else on failure should call the callback
+        failure_value = failure_result.get_or_else(lambda e: 42)
+        self.assertEqual(failure_value, 42)
+
+        # get_or_else on failure can use the exception
+        failure_msg = failure_result.get_or_else(lambda e: f"Error occurred: {e}")
+        self.assertEqual(failure_msg, "Error occurred: test error")
+
+        # get_or_else with exception in lambda should throw
+        with self.assertRaises(ZeroDivisionError):
+            failure_result.get_or_else(lambda e: 1 / 0)
+
+    def test_kotlin_naming_aliases(self):
+        """Test Kotlin naming compatibility aliases"""
+        success_result = Result.success("test value")
+        failure_result = Result.failure(ValueError("test error"))
+
+        # Test getOrNull (alias for get_or_null)
+        self.assertEqual(success_result.getOrNull(), "test value")
+        self.assertIsNone(failure_result.getOrNull())
+
+        # Test exceptionOrNull (alias for exception_or_null)
+        self.assertIsNone(success_result.exceptionOrNull())
+        self.assertIsInstance(failure_result.exceptionOrNull(), ValueError)
+
+    def test_get_or_null_and_exception_or_null(self):
+        """Test get_or_null and exception_or_null main methods"""
+        success_result = Result.success("test value")
+        failure_result = Result.failure(ValueError("test error"))
+
+        # Test get_or_null
+        self.assertEqual(success_result.get_or_null(), "test value")
+        self.assertIsNone(failure_result.get_or_null())
+
+        # Test exception_or_null
+        self.assertIsNone(success_result.exception_or_null())
+        self.assertIsInstance(failure_result.exception_or_null(), ValueError)
+
+        # Test that get_or_none is an alias for get_or_null
+        self.assertEqual(success_result.get_or_null(), success_result.get_or_none())
+        self.assertEqual(failure_result.get_or_null(), failure_result.get_or_none())
+
+        # Test that exception_or_none is an alias for exception_or_null
+        self.assertEqual(success_result.exception_or_null(), success_result.exception_or_none())
+        self.assertEqual(failure_result.exception_or_null(), failure_result.exception_or_none())
+
+    def test_str_and_repr(self):
+        """Test __str__ and __repr__ methods"""
+        success_result = Result.success("test value")
+        failure_result = Result.failure(ValueError("test error"))
+
+        # Test __str__
+        self.assertEqual(str(success_result), "Success(test value)")
+        self.assertEqual(str(failure_result), "Failure(test error)")
+
+        # Test __repr__
+        self.assertEqual(repr(success_result), "Result.success('test value')")
+        self.assertEqual(repr(failure_result), "Result.failure(ValueError('test error'))")
+
+    def test_equality(self):
+        """Test __eq__ and __ne__ methods"""
+        # Success results with same value should be equal
+        result1 = Result.success(42)
+        result2 = Result.success(42)
+        result3 = Result.success(43)
+        self.assertEqual(result1, result2)
+        self.assertNotEqual(result1, result3)
+
+        # Failure results with same exception should be equal
+        error1 = Result.failure(ValueError("error"))
+        error2 = Result.failure(ValueError("error"))
+        error3 = Result.failure(ValueError("different"))
+        error4 = Result.failure(TypeError("error"))
+        self.assertEqual(error1, error2)
+        self.assertNotEqual(error1, error3)
+        self.assertNotEqual(error1, error4)
+
+        # Success and failure should never be equal
+        self.assertNotEqual(Result.success(42), Result.failure(ValueError("error")))
+
+        # Result should not be equal to non-Result
+        self.assertNotEqual(Result.success(42), 42)
+        self.assertNotEqual(Result.success(42), "42")
+
+    def test_hash(self):
+        """Test __hash__ method"""
+        # Same success results should have same hash
+        result1 = Result.success(42)
+        result2 = Result.success(42)
+        self.assertEqual(hash(result1), hash(result2))
+
+        # Same failure results should have same hash
+        error1 = Result.failure(ValueError("error"))
+        error2 = Result.failure(ValueError("error"))
+        self.assertEqual(hash(error1), hash(error2))
+
+        # Results can be used in sets
+        result_set = {Result.success(1), Result.success(2), Result.success(1)}
+        self.assertEqual(len(result_set), 2)
+
+        # Results can be used as dict keys
+        result_dict = {Result.success(1): "one", Result.failure(ValueError("e")): "error"}
+        self.assertEqual(result_dict[Result.success(1)], "one")
+        self.assertEqual(result_dict[Result.failure(ValueError("e"))], "error")

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -273,19 +273,6 @@ class TestResult(unittest.TestCase):
         with self.assertRaises(ZeroDivisionError):
             failure_result.get_or_else(lambda e: 1 / 0)
 
-    def test_kotlin_naming_aliases(self):
-        """Test Kotlin naming compatibility aliases"""
-        success_result = Result.success("test value")
-        failure_result = Result.failure(ValueError("test error"))
-
-        # Test getOrNull (alias for get_or_null)
-        self.assertEqual(success_result.getOrNull(), "test value")
-        self.assertIsNone(failure_result.getOrNull())
-
-        # Test exceptionOrNull (alias for exception_or_null)
-        self.assertIsNone(success_result.exceptionOrNull())
-        self.assertIsInstance(failure_result.exceptionOrNull(), ValueError)
-
     def test_get_or_null_and_exception_or_null(self):
         """Test get_or_null and exception_or_null main methods"""
         success_result = Result.success("test value")

--- a/tests/test_run_catching.py
+++ b/tests/test_run_catching.py
@@ -1,6 +1,6 @@
 import unittest
 
-from kotresult import run_catching
+from kotresult import run_catching, run_catching_with
 
 
 class TestRunCatching(unittest.TestCase):
@@ -64,3 +64,85 @@ class TestRunCatching(unittest.TestCase):
         result = run_catching(lambda x: x * 2, 5)
         self.assertTrue(result.is_success)
         self.assertEqual(result.get_or_none(), 10)
+
+
+class TestRunCatchingWith(unittest.TestCase):
+    def test_successful_function_with_receiver(self):
+        """Test run_catching_with with a function that succeeds"""
+        
+        def get_length(s):
+            return len(s)
+        
+        result = run_catching_with("hello", get_length)
+        self.assertTrue(result.is_success)
+        self.assertEqual(result.get_or_null(), 5)
+    
+    def test_method_call_with_receiver(self):
+        """Test run_catching_with with a method call"""
+        
+        def upper_case(s):
+            return s.upper()
+        
+        result = run_catching_with("hello world", upper_case)
+        self.assertTrue(result.is_success)
+        self.assertEqual(result.get_or_null(), "HELLO WORLD")
+    
+    def test_function_with_additional_args(self):
+        """Test run_catching_with with additional arguments"""
+        
+        def add_prefix(s, prefix):
+            return prefix + s
+        
+        result = run_catching_with("world", add_prefix, "Hello, ")
+        self.assertTrue(result.is_success)
+        self.assertEqual(result.get_or_null(), "Hello, world")
+    
+    def test_function_with_kwargs(self):
+        """Test run_catching_with with keyword arguments"""
+        
+        def format_string(s, prefix="", suffix=""):
+            return f"{prefix}{s}{suffix}"
+        
+        result = run_catching_with("Python", format_string, prefix="Hello, ", suffix="!")
+        self.assertTrue(result.is_success)
+        self.assertEqual(result.get_or_null(), "Hello, Python!")
+    
+    def test_lambda_with_receiver(self):
+        """Test run_catching_with with a lambda function"""
+        
+        result = run_catching_with(10, lambda x: x * x)
+        self.assertTrue(result.is_success)
+        self.assertEqual(result.get_or_null(), 100)
+    
+    def test_failing_function_with_receiver(self):
+        """Test run_catching_with with a function that raises an exception"""
+        
+        def parse_int(s):
+            return int(s)
+        
+        result = run_catching_with("not a number", parse_int)
+        self.assertTrue(result.is_failure)
+        self.assertIsInstance(result.exception_or_null(), ValueError)
+    
+    def test_type_conversion_with_receiver(self):
+        """Test run_catching_with for type conversion"""
+        
+        # Successful conversion
+        result = run_catching_with("42", int)
+        self.assertTrue(result.is_success)
+        self.assertEqual(result.get_or_null(), 42)
+        
+        # Failed conversion
+        result = run_catching_with("abc", int)
+        self.assertTrue(result.is_failure)
+        self.assertIsInstance(result.exception_or_null(), ValueError)
+    
+    def test_chaining_with_receiver(self):
+        """Test run_catching_with can be used in chains"""
+        
+        def process_string(s):
+            return s.strip().upper()
+        
+        result = run_catching_with("  hello  ", process_string)
+        self.assertTrue(result.is_success)
+        self.assertEqual(result.get_or_null(), "HELLO")


### PR DESCRIPTION
This pull request introduces significant enhancements to the `kotresult` library, focusing on improving the `Result` class API, adding new methods for functional programming, and extending functionality with the `run_catching_with` method. It also includes updates to documentation and tests to reflect these changes.

### Enhancements to the `Result` class:

* Added new methods to the `Result` class:
  - `map` and `map_catching`: Transform success values, with `map_catching` handling exceptions during transformation.
  - `recover` and `recover_catching`: Transform failure exceptions into success values, with `recover_catching` handling exceptions during recovery.
  - [`fold`](diffhunk://#diff-8ac0a62ac1464df082d23f28dcb5b4c4df507866ee5579ac9f609058a6a303efR76-R142): Handle both success and failure cases with a single call.
  - [`get_or_else`](diffhunk://#diff-8ac0a62ac1464df082d23f28dcb5b4c4df507866ee5579ac9f609058a6a303efR76-R142): Compute an alternative value from the exception if the result is a failure.

* Renamed `get_or_none` and `exception_or_none` to `get_or_null` and `exception_or_null`, respectively, while maintaining aliases for Python naming conventions.

### New `run_catching_with` function:

* Introduced `run_catching_with`, which allows executing a function with a receiver object as the first argument, mimicking Kotlin's extension function behavior.

### Documentation updates:

* Expanded the `README.md` with detailed examples of advanced methods (`map`, `recover`, `fold`, etc.), chaining operations, and usage of the new `run_catching_with` function. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R157-R305) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L173-R346)

### Testing improvements:

* Updated unit tests to reflect changes in method names (`get_or_null`, `exception_or_null`) and added tests for new methods (`map`, `recover`, `fold`, etc.). [[1]](diffhunk://#diff-2c0771724e9886ac20d94971066455855a26b2bbf4f5d5dc094e36a5a50cd19eL12-R22) [[2]](diffhunk://#diff-2c0771724e9886ac20d94971066455855a26b2bbf4f5d5dc094e36a5a50cd19eR84-R87) [[3]](diffhunk://#diff-2c0771724e9886ac20d94971066455855a26b2bbf4f5d5dc094e36a5a50cd19eR110-R113)

### Version bump:

* Updated the library version from `0.2.0` to `1.0.0` to signify the major changes and new features.